### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [ ![Download](https://api.bintray.com/packages/vanshg/maven/Scale/images/download.svg) ](https://bintray.com/vanshg/maven/Scale/_latestVersion)
 [![license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://github.com/vanshg/Scale/blob/master/LICENSE)
 ![API](https://img.shields.io/badge/API-8%2B-blue.svg?style=flat)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/AudioTranscription/functions?utm_source=ScaleGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 ##Requirements
 * Minimum Andorid SDK Level 8 or higher


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out Scale API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!